### PR TITLE
Remove unsafe code

### DIFF
--- a/src/construct/sacak/sacak_u32s/mod.rs
+++ b/src/construct/sacak/sacak_u32s/mod.rs
@@ -122,13 +122,7 @@ fn sort_lms_suffixes(s: &[u32], sa: &mut [u32]) {
                 sa[q] = tmp;
             } else {
                 let t = q + 1 - m;
-                unsafe {
-                    std::ptr::copy(
-                        &sa[l] as *const u32,
-                        &mut sa[t] as *mut u32,
-                        m,
-                    );
-                }
+                sa.copy_within(l..l+m, t);
                 sa[l..Ord::min(r, t)].iter_mut().for_each(|i| *i = EMPTY);
             }
 
@@ -329,13 +323,7 @@ fn finish_head(sa: &mut [u32]) {
     for p in 1..sa.len() {
         if sa[p] > EMPTY {
             let n = -(sa[p] as i32) as usize;
-            unsafe {
-                std::ptr::copy(
-                    &sa[p + 1] as *const u32,
-                    &mut sa[p] as *mut u32,
-                    n,
-                );
-            }
+            sa.copy_within(p+1..p+n+1, p);
             sa[p + n] = EMPTY;
         }
     }
@@ -347,13 +335,7 @@ fn finish_tail(sa: &mut [u32]) {
     for p in (1..sa.len()).rev() {
         if sa[p] > EMPTY {
             let n = -(sa[p] as i32) as usize;
-            unsafe {
-                std::ptr::copy(
-                    &sa[p - n] as *const u32,
-                    &mut sa[p - n + 1] as *mut u32,
-                    n,
-                );
-            }
+            sa.copy_within(p-n..p, p-n+1);
             sa[p - n] = EMPTY;
         }
     }
@@ -367,9 +349,8 @@ fn sa_move(
     n: usize,
     ptr: &mut Option<&mut usize>,
 ) {
-    unsafe {
-        std::ptr::copy(&sa[src] as *const u32, &mut sa[dst] as *mut u32, n);
-    }
+    sa.copy_within(src..src+n, dst);
+
     if let Some(p) = std::mem::replace(ptr, None) {
         if *p >= src && *p < src + n {
             if dst >= src {

--- a/src/construct/utils.rs
+++ b/src/construct/utils.rs
@@ -62,13 +62,7 @@ pub fn suffixes_from_substrs<'s, T, F>(
     // 2. sort lms suffixes
     if k + 1 == tail.len() {
         // lms substrings => lms suffixes
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                &tail[0] as *const u32,
-                &mut head[0] as *mut u32,
-                tail.len(),
-            );
-        }
+        &head[0..tail.len()].copy_from_slice(tail);
     } else {
         // construct sub-problem
         let mut t = 0;
@@ -83,13 +77,8 @@ pub fn suffixes_from_substrs<'s, T, F>(
         sort(&mut head[..t], k, tail);
 
         // rearrange the lms suffixes
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                &tail[0] as *const u32,
-                &mut head[0] as *mut u32,
-                tail.len(),
-            );
-        }
+        &head[0..tail.len()].copy_from_slice(tail);
+
         let mut h = tail.len();
         for_each_lms(s, true, |i, _| {
             h -= 1;


### PR DESCRIPTION
- `std::ptr::copy_nonoverlapping` was used to copy between different slices, where `slice::copy_from_slice` safely results in [the same call to `ptr::copy_nonoverlapping`].
- `std::ptr::copy` was used to move data within a single slice, where `slice::copy_within` safely results in [the same call to `ptr::copy`].

[the same call to `ptr::copy_nonoverlapping`]: https://doc.rust-lang.org/src/core/slice/mod.rs.html#2137-2144
[the same call to `ptr::copy`]: https://doc.rust-lang.org/src/core/slice/mod.rs.html#2171-2200